### PR TITLE
Add PlantUML compatible routes

### DIFF
--- a/src/main/java/uml/memo/controller/UmlController.java
+++ b/src/main/java/uml/memo/controller/UmlController.java
@@ -26,23 +26,38 @@ public class UmlController {
 
     @GetMapping(path = { "/uml/{encoded}", "/uml/{encoded}.png" }, produces = MediaType.IMAGE_PNG_VALUE)
     public byte[] image(@PathVariable String encoded) throws IOException, MemcachedService.Exception {
-        return umlService.decodeImageWithCache(encoded, FileFormat.PNG);
+        return umlService.decodeImageWithCache(encoded, FileFormat.PNG, false);
     }
 
     @GetMapping(path = "/uml/{encoded}.svg", produces = IMAGE_SVG_VALUE)
     public byte[] imageSvg(@PathVariable String encoded) throws IOException, MemcachedService.Exception {
-        return umlService.decodeImageWithCache(encoded, FileFormat.SVG);
+        return umlService.decodeImageWithCache(encoded, FileFormat.SVG, false);
     }
 
     @GetMapping(path = "/uml/{encoded}.txt", produces = MediaType.TEXT_PLAIN_VALUE)
     public String imageTxt(@PathVariable String encoded) throws IOException, MemcachedService.Exception {
-        byte[] bytes = umlService.decodeImageWithCache(encoded, FileFormat.UTXT);
+        byte[] bytes = umlService.decodeImageWithCache(encoded, FileFormat.UTXT, false);
         return new String(bytes, StandardCharsets.UTF_8);
     }
 
     @GetMapping(path = "/uml/{encoded}.atxt", produces = MediaType.TEXT_PLAIN_VALUE)
     public String imageAsciiTxt(@PathVariable String encoded) throws IOException, MemcachedService.Exception {
-        byte[] bytes = umlService.decodeImageWithCache(encoded, FileFormat.ATXT);
+        byte[] bytes = umlService.decodeImageWithCache(encoded, FileFormat.ATXT, false);
         return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    @GetMapping(path = "/plantuml/png/{encoded}", produces = MediaType.IMAGE_PNG_VALUE)
+    public byte[] imagePngForPlantUmlEncode(@PathVariable String encoded) throws IOException, MemcachedService.Exception {
+        return umlService.decodeImageWithCache(encoded, FileFormat.PNG, true);
+    }
+
+    @GetMapping(path = "/plantuml/svg/{encoded}", produces = IMAGE_SVG_VALUE)
+    public byte[] imageSvgForPlantUmlEncode(@PathVariable String encoded) throws IOException, MemcachedService.Exception {
+        return umlService.decodeImageWithCache(encoded, FileFormat.SVG, true);
+    }
+
+    @GetMapping(path = "/plantuml/txt/{encoded}", produces = MediaType.TEXT_PLAIN_VALUE)
+    public byte[] imageTxtForPlantUmlEncode(@PathVariable String encoded) throws IOException, MemcachedService.Exception {
+        return umlService.decodeImageWithCache(encoded, FileFormat.ATXT, true);
     }
 }

--- a/src/main/java/uml/memo/service/UmlService.java
+++ b/src/main/java/uml/memo/service/UmlService.java
@@ -3,6 +3,7 @@ package uml.memo.service;
 import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.FileFormatOption;
 import net.sourceforge.plantuml.SourceStringReader;
+import net.sourceforge.plantuml.code.TranscoderUtil;
 import net.sourceforge.plantuml.core.DiagramDescription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,13 +49,17 @@ public class UmlService {
         }
     }
 
-    public byte[] decodeImageWithCache(String encodedUml, FileFormat format) throws IOException, MemcachedService.Exception {
+    public String decodePlantUmlString(String encoded) throws IOException {
+        return TranscoderUtil.getDefaultTranscoder().decode(encoded);
+    }
+
+    public byte[] decodeImageWithCache(String encodedUml, FileFormat format, boolean isPlantUmlEncode) throws IOException, MemcachedService.Exception {
         String key = "uml:" + format.name() + ":" + DigestUtils.md5DigestAsHex(encodedUml.getBytes(StandardCharsets.UTF_8));
         Optional<byte[]> cache = memcachedService.get(key);
         if (cache.isPresent()) {
             return cache.get();
         }
-        String uml = decode(encodedUml);
+        String uml = isPlantUmlEncode ? decodePlantUmlString(encodedUml) : decode(encodedUml);
         byte[] image = generateImage(uml, format);
         memcachedService.put(key, image);
         return image;

--- a/src/main/java/uml/memo/service/UmlService.java
+++ b/src/main/java/uml/memo/service/UmlService.java
@@ -54,7 +54,7 @@ public class UmlService {
     }
 
     public byte[] decodeImageWithCache(String encodedUml, FileFormat format, boolean isPlantUmlEncode) throws IOException, MemcachedService.Exception {
-        String key = "uml:" + format.name() + ":" + DigestUtils.md5DigestAsHex(encodedUml.getBytes(StandardCharsets.UTF_8));
+        String key = "uml:" + format.name() + ":" + isPlantUmlEncode + ":" + DigestUtils.md5DigestAsHex(encodedUml.getBytes(StandardCharsets.UTF_8));
         Optional<byte[]> cache = memcachedService.get(key);
         if (cache.isPresent()) {
             return cache.get();


### PR DESCRIPTION
Add svg/png/atxt actions which compatible PlantUML server.
(demo server: http://www.plantuml.com/ )
I test with [vscode-plantuml](https://marketplace.visualstudio.com/items?itemName=jebbs.plantuml).

For example. this plantuml document is converted into below url (if uml-memo server is in localhost).

```plantuml
@startuml
Bob -> Alice : hello
@enduml
```

http://localhost:8080/plantuml/txt/SoWkIImgAStDuNBAJrBGjLDmpCbCJbMmKl18pSd9vt98pKi1IW80

----

PlantUML serverで実装されているURL形式に対応したsvg/png/atxt形式を返すアクションを追加しました。
PlantUML server形式のbase64は普通のbase64ではないようで、ちょっと分岐を入れています。
https://github.com/plantuml/plantuml-server/blob/v1.2020.14/src/main/java/net/sourceforge/plantuml/servlet/PlantUmlServlet.java#L131
既存のURL形式の互換性は残しておきたいだろうとおもったので残しました。
